### PR TITLE
Fix bug in Matomo plugin when `matomoGlobalLoaded = true`

### DIFF
--- a/src/plugins/es.upv.paella.matomo.userTrackingDataPlugin.js
+++ b/src/plugins/es.upv.paella.matomo.userTrackingDataPlugin.js
@@ -108,10 +108,10 @@ export default class MatomoUserTrackingDataPlugin extends DataPlugin {
         if (this.matomoGlobalLoaded) {
             var _paq = window._paq = window._paq || [];
             this.player.log.debug('Assuming Matomo analytics is initialized globaly.');
-            if (server) {
+            if (this.config.server) {
                 this.player.log.warn('Matomo plugin: `server` parameter is defined, but never used because Matomo is loaded globaly in the page. Is it an error? Please check it.');
             }
-            if (siteId) {
+            if (this.config.siteId) {
                 this.player.log.warn('Matomo plugin: `siteId` parameter is defined, but never used because Matomo is loaded globaly in the page. Is it an error? Please check it.');
             }
         }


### PR DESCRIPTION
The `load` function previously aborted with an error because `server` was not defined. Pretty sure the code meant to check the fields in the config.