### PR TITLE
Added configuration settings for the URLs of the Matomo trackers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,13 @@ Collects the events sent by the `es.upv.paella.userEventTracker` plugin and send
         "enabled": false,
         "context": [
             "userTracking"
-        ],        
+        ],
         "server": "//matomo.server.com/",
         "siteId": "1",
+        "trackerUrl": {
+            "php": "matomo.php",
+            "js": "matomo.js"
+        },
         "matomoGlobalLoaded": false,
         "events": {
             "category": "PaellaPlayer",

--- a/config/config.json
+++ b/config/config.json
@@ -158,6 +158,10 @@
             ],
             "server": "//matomo.server.com/",
             "siteId": "1",
+            "trackerUrl": {
+                "php": "matomo.php",
+                "js": "matomo.js"
+            },
             "matomoGlobalLoaded": false,
             "cookieType": "tracking",
             "events": {

--- a/src/plugins/es.upv.paella.matomo.userTrackingDataPlugin.js
+++ b/src/plugins/es.upv.paella.matomo.userTrackingDataPlugin.js
@@ -118,6 +118,10 @@ export default class MatomoUserTrackingDataPlugin extends DataPlugin {
         else {
             const server = this.server;
             const siteId = this.siteId;            
+            const trackerUrl = {
+                php: this.config.trackerUrl?.php ?? 'matomo.php',
+                js: this.config.trackerUrl?.js ?? 'matomo.js'
+            };
             this.player.log.debug("Matomo analytics plugin enabled.");
             this.trackCustomDimensions();
             const userId =  await this.getCurrentUserId();
@@ -128,10 +132,10 @@ export default class MatomoUserTrackingDataPlugin extends DataPlugin {
             _paq.push(['enableLinkTracking']);
             (function() {
                 var u=server;
-                _paq.push(['setTrackerUrl', u+'matomo.php']);
+                _paq.push(['setTrackerUrl', u+trackerUrl.php]);
                 _paq.push(['setSiteId', siteId]);
                 var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-                g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+                g.type='text/javascript'; g.async=true; g.src=u+trackerUrl.js; s.parentNode.insertBefore(g,s);
             })();
         }
         // accurately measure the time spent in the visit


### PR DESCRIPTION
This pull request adds configuration settings to customize the URLs of the Matomo trackers (js/php).

Fixes https://github.com/polimediaupv/paella-user-tracking/issues/6