### PR TITLE
Send video title information for Matomo Media Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,10 +171,11 @@ Collects the events sent by the `es.upv.paella.userEventTracker` plugin and send
             "js": "matomo.js"
         },
         "matomoGlobalLoaded": false,
+        "mediaAnalyticsTitle": "${videoId}",
         "events": {
             "category": "PaellaPlayer",
             "action": "${event}",
-            "name": "${videoId}"
+            "name": "${eventData}"
         },
         "customDimensions": {
             "1": "${videoId}"
@@ -210,6 +211,8 @@ Available template variables are:
 }
 ```
 
+The `mediaAnalyticsTitle` property defines the template variable that will be used as title information in the Matomo Media Analytics plugin. If not set, `document.title` will be used.
+
 ### Adapt to your institution
 
 You can extends this plugin and adapt it to your institution. In most cases you only need to implement two functions:
@@ -228,7 +231,7 @@ export default class MyExtentedMatomoUserTrackingDataPlugin extends MatomoUserTr
 
     async getTemplateVars() {
         let templateVars = await super.getTemplateVars();
-        
+
         return {
             ...templateVars,
             newvar: "My new variable"
@@ -257,5 +260,3 @@ Collects the events sent by the `es.upv.paella.userEventTracker` plugin and send
 ```
 
 **Exported as** `GoogleAnalyticsUserTrackingDataPlugin`.
-
-

--- a/config/config.json
+++ b/config/config.json
@@ -3,7 +3,7 @@
     "manifestFileName": "data.json",
 
     "defaultLayout": "presenter-presentation",
-    
+
     "cookieConsent": [
         {
             "type": "strictly-necessary",
@@ -87,7 +87,7 @@
             "enabled": true,
             "order": 1
         },
-        
+
         "es.upv.paella.playPauseButton": {
             "enabled": true,
             "order": 0
@@ -164,10 +164,11 @@
             },
             "matomoGlobalLoaded": false,
             "cookieType": "tracking",
+            "mediaAnalyticsTitle": "${videoId}",
             "events": {
                 "category": "PaellaPlayer",
                 "action": "${event}",
-                "name": "${videoId}"
+                "name": "${eventData}"
             },
             "customDimensions": {
                 "1": "${videoId}"
@@ -175,4 +176,3 @@
         }
     }
 }
-


### PR DESCRIPTION
fixes https://github.com/polimediaupv/paella-user-tracking/issues/8

Video title information was missing for the Matomo Media Analytics plugin. Therefore the `data-matomo-title`attribute needs to be added to the `video` tag. If there are multiple videos, only one `video` tag needs to be considered. All other `video` tags must be ignored by the Media Analytics plugin. This is done by setting the `data-matomo-ignore`attribute for all other `video`tags.
Use the `mediaAnalyticsTitle` config parameter to define the template variable to be used as title for Media Analytics. If the parameter is not set, `document.title` will be used instead.