### PR TITLE
Add the option to disable the use of beacons for Matomo

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Collects the events sent by the `es.upv.paella.userEventTracker` plugin and send
             "js": "matomo.js"
         },
         "matomoGlobalLoaded": false,
+        "disableAlwaysUseSendBeacon": true,
         "mediaAnalyticsTitle": "${videoId}",
         "events": {
             "category": "PaellaPlayer",
@@ -210,6 +211,10 @@ Available template variables are:
     "1": "${videoId}"
 }
 ```
+
+The `disableAlwaysUseSendBeacon` property allows to disable the use of beacons. With the default setting, Matomo uses the `navigator.sendBeacon()` method to send analytics data asynchronously via an HTTP POST request.
+Unfortunately, ad blockers use these beacons to identify and block such requests. Setting `disableAlwaysUseSendBeacon` to true will prevent Matomo from using such beacons. For more information have a look at https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon
+
 
 The `mediaAnalyticsTitle` property defines the template variable that will be used as title information in the Matomo Media Analytics plugin. If not set, `document.title` will be used.
 

--- a/src/plugins/es.upv.paella.matomo.userTrackingDataPlugin.js
+++ b/src/plugins/es.upv.paella.matomo.userTrackingDataPlugin.js
@@ -121,6 +121,7 @@ export default class MatomoUserTrackingDataPlugin extends DataPlugin {
                 php: this.config.trackerUrl?.php ?? 'matomo.php',
                 js: this.config.trackerUrl?.js ?? 'matomo.js'
             };
+            const disableAlwaysUseSendBeacon = this.config.disableAlwaysUseSendBeacon ?? false;
             this.player.log.debug("Matomo analytics plugin enabled.");
             this.trackCustomDimensions();
             const userId =  await this.getCurrentUserId();
@@ -133,6 +134,9 @@ export default class MatomoUserTrackingDataPlugin extends DataPlugin {
                 var u=server;
                 window._paq.push(['setTrackerUrl', u+trackerUrl.php]);
                 window._paq.push(['setSiteId', siteId]);
+                if (disableAlwaysUseSendBeacon) {
+                    window._paq.push(['disableAlwaysUseSendBeacon', 'true']);
+                }
                 var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
                 g.type='text/javascript'; g.async=true; g.src=u+trackerUrl.js; s.parentNode.insertBefore(g,s);
             })();


### PR DESCRIPTION
With the default setting, Matomo uses the `navigator.sendBeacon()` method to send analytics data asynchronously via an HTTP POST request. Unfortunately, ad blockers use these beacons to identify and block such requests. The new config parameter `disableAlwaysUseSendBeacon` allows to disable the use of such beacons.

For more information have a look at https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon